### PR TITLE
DataFrame comparisons along rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Collate: S4-utils.R
 	SimpleList-class.R
 	HitsList-class.R
 	DataFrame-class.R
+    DataFrame-comparison.R
 	Pairs-class.R
 	expand-methods.R
 	FilterRules-class.R

--- a/R/DataFrame-comparison.R
+++ b/R/DataFrame-comparison.R
@@ -5,8 +5,13 @@ setMethod("sameAsLastROW", "DataFrame", function(x) {
     Reduce("&", is.diff)
 })
 
+# Necessary to avoid using match,List,List-method.
+setMethod("match", c("DataFrame", "DataFrame"), function (x, table, nomatch = NA_integer_, incomparables = NULL, ...) {
+    FUN <- selectMethod("match", c("Vector", "Vector"))
+    FUN(x, table, nomatch=nomatch, incomparables=incomparables)
+})
+
 setMethod("order", "DataFrame", function(..., na.last = TRUE, decreasing = FALSE, method = c("auto", "shell", "radix")) {
-    contents <- lapply(list(...), as.list)
-    contents <- unlist(contents, recursive=FALSE)
+    contents <- as.list(cbind(...))
     do.call(order, c(contents, list(na.last=na.last, decreasing=decreasing, method=method)))
 })

--- a/R/DataFrame-comparison.R
+++ b/R/DataFrame-comparison.R
@@ -1,0 +1,62 @@
+
+setMethod("match", c("DataFrame", "DataFrame"), function(x, table, nomatch = NA_integer_, incomparables = NULL, ...) {
+    # table first, so stable ordering means that, of matched entries,
+    # the one from 'table' gets sorted before that from 'x'.
+    combined <- rbind(table, x)
+    origins <- c(seq_len(nrow(table)), rep(NA_integer_, nrow(x))) 
+
+    if (nrow(table)==0L) {
+        return(origins)
+    } else if (nrow(x)==0L) {
+        return(integer(0))
+    }
+
+    o <- order(combined)
+    combined <- combined[o,,drop=FALSE]
+    origins <- origins[o]
+
+    is.diff <- lapply(as.list(combined), FUN=function(y) c(TRUE, y[-1]!=y[-nrow(combined)]))
+    is.unique <- Reduce("|", is.diff)
+    m <- cumsum(is.unique)
+
+    origins <- origins[is.unique][m]
+    origins[o] <- origins
+    origins <- tail(origins, nrow(x))
+
+    origins[is.na(origins)] <- nomatch
+    origins
+})
+
+setMethod("selfmatch", "DataFrame", function(x, ...) {
+    o <- order(x)
+    x <- x[o,,drop=FALSE]
+
+    is.diff <- lapply(as.list(x), FUN=function(y) c(TRUE, y[-1]!=y[-nrow(x)]))
+    is.unique <- Reduce("|", is.diff)
+    m <- cumsum(is.unique)
+
+    origins <- o[is.unique][m]
+    origins[o] <- origins
+    origins
+})
+
+# One method for pure DF ordering, and xtfrm for mixed DF/other things.
+setMethod("order", "DataFrame", function(..., na.last = TRUE, decreasing = FALSE, method = c("auto", "shell", "radix")) {
+    contents <- lapply(list(...), as.list)
+    contents <- unlist(contents, recursive=FALSE)
+    do.call(order, c(contents, list(na.last=na.last, decreasing=decreasing, method=method)))
+})
+
+setMethod("xtfrm", "DataFrame", function (x) {
+    if (nrow(x)==0L) return(integer(0))
+
+    o <- do.call(order, as.list(x))
+    x <- x[o,,drop=FALSE]
+    is.diff <- lapply(as.list(x), FUN=function(y) c(TRUE, y[-1]!=y[-nrow(x)]))
+    is.unique <- Reduce("|", is.diff)
+
+    out.rank <- cumsum(is.unique)
+    out.rank[o] <- out.rank
+    out.rank
+})
+

--- a/R/DataFrame-comparison.R
+++ b/R/DataFrame-comparison.R
@@ -1,62 +1,12 @@
-
-setMethod("match", c("DataFrame", "DataFrame"), function(x, table, nomatch = NA_integer_, incomparables = NULL, ...) {
-    # table first, so stable ordering means that, of matched entries,
-    # the one from 'table' gets sorted before that from 'x'.
-    combined <- rbind(table, x)
-    origins <- c(seq_len(nrow(table)), rep(NA_integer_, nrow(x))) 
-
-    if (nrow(table)==0L) {
-        return(origins)
-    } else if (nrow(x)==0L) {
-        return(integer(0))
-    }
-
-    o <- order(combined)
-    combined <- combined[o,,drop=FALSE]
-    origins <- origins[o]
-
-    is.diff <- lapply(as.list(combined), FUN=function(y) c(TRUE, y[-1]!=y[-nrow(combined)]))
-    is.unique <- Reduce("|", is.diff)
-    m <- cumsum(is.unique)
-
-    origins <- origins[is.unique][m]
-    origins[o] <- origins
-    origins <- tail(origins, nrow(x))
-
-    origins[is.na(origins)] <- nomatch
-    origins
+# Slightly more efficient than relying on the Vector method,
+# which would need to invoke pcompare() and related checks.
+setMethod("sameAsLastROW", "DataFrame", function(x) {
+    is.diff <- lapply(x, FUN=sameAsLastROW)
+    Reduce("&", is.diff)
 })
 
-setMethod("selfmatch", "DataFrame", function(x, ...) {
-    o <- order(x)
-    x <- x[o,,drop=FALSE]
-
-    is.diff <- lapply(as.list(x), FUN=function(y) c(TRUE, y[-1]!=y[-nrow(x)]))
-    is.unique <- Reduce("|", is.diff)
-    m <- cumsum(is.unique)
-
-    origins <- o[is.unique][m]
-    origins[o] <- origins
-    origins
-})
-
-# One method for pure DF ordering, and xtfrm for mixed DF/other things.
 setMethod("order", "DataFrame", function(..., na.last = TRUE, decreasing = FALSE, method = c("auto", "shell", "radix")) {
     contents <- lapply(list(...), as.list)
     contents <- unlist(contents, recursive=FALSE)
     do.call(order, c(contents, list(na.last=na.last, decreasing=decreasing, method=method)))
 })
-
-setMethod("xtfrm", "DataFrame", function (x) {
-    if (nrow(x)==0L) return(integer(0))
-
-    o <- do.call(order, as.list(x))
-    x <- x[o,,drop=FALSE]
-    is.diff <- lapply(as.list(x), FUN=function(y) c(TRUE, y[-1]!=y[-nrow(x)]))
-    is.unique <- Reduce("|", is.diff)
-
-    out.rank <- cumsum(is.unique)
-    out.rank[o] <- out.rank
-    out.rank
-})
-

--- a/R/DataFrame-comparison.R
+++ b/R/DataFrame-comparison.R
@@ -33,3 +33,7 @@ setMethod("pcompare", c("DataFrame", "DataFrame"), function(x, y) {
     compared
 })
 
+# Necessary to avoid using Ops for Lists.
+setMethod("==", c("DataFrame", "DataFrame"), function(e1, e2) pcompare(e1, e2) == 0L)
+
+setMethod("<=", c("DataFrame", "DataFrame"), function(e1, e2) pcompare(e1, e2) <= 0L)

--- a/R/DataFrame-comparison.R
+++ b/R/DataFrame-comparison.R
@@ -15,3 +15,21 @@ setMethod("order", "DataFrame", function(..., na.last = TRUE, decreasing = FALSE
     contents <- as.list(cbind(...))
     do.call(order, c(contents, list(na.last=na.last, decreasing=decreasing, method=method)))
 })
+
+setMethod("pcompare", c("DataFrame", "DataFrame"), function(x, y) {
+    fields <- colnames(x)
+    N <- max(NROW(x), NROW(y))
+    if (!identical(sort(fields), sort(colnames(y)))) {
+        return(logical(N))
+    }
+
+    compared <- integer(N)
+    for (f in fields) {
+        current <- pcompare(x[[f]], y[[f]])
+        keep <- compared==0L
+        compared[keep] <- current[keep]
+    }
+
+    compared
+})
+

--- a/R/Vector-class.R
+++ b/R/Vector-class.R
@@ -729,7 +729,6 @@ setMethod("append", c("Vector", "Vector"),
     }
 )
 
-
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Evaluating
 ###

--- a/R/Vector-comparison.R
+++ b/R/Vector-comparison.R
@@ -80,7 +80,7 @@ setMethod("sameAsLastROW", "ANY", function(x) {
 ### match()
 ###
 ### The default "match" method below is implemented on top of 
-### sameAsLastROWS() and order().
+### selfmatch().
 ###
 
 setMethod("match", c("Vector", "Vector"), 

--- a/R/Vector-comparison.R
+++ b/R/Vector-comparison.R
@@ -139,21 +139,21 @@ setMethod("selfmatch", "factor", function(x, ..., incomparables = NULL) {
 
 ### Vector-based "selfmatch" method, slightly more efficient than match(x, x).
 setMethod("selfmatch", "ANY", function(x, nomatch = NA_integer_, incomparables = NULL, ...) {
-    o <- order(x)
-    y <- extractROWS(x, o)
+    if (length(x)==0L) return(integer(0))
 
-    is.unique <- !sameAsLastROW(y)
-    m <- cumsum(is.unique)
+    g <- grouping(x)
+    ends <- attr(g, "ends")
+    starts <- c(1L, head(ends, -1L) + 1L)
+    first.of.kind <- g[starts]
 
-    origins <- o[is.unique][m]
-    origins[o] <- origins
-
-    origins[is.na(origins)] <- nomatch
     if (!is.null(incomparables)) {
-        origins[x %in% incomparables] <- nomatch
+        first.x <- extractROWS(x, first.of.kind)
+        first.of.kind[first.x %in% incomparables] <- nomatch
     }
 
-    origins
+    ans <- integer(NROW(x))
+    ans[g] <- rep(first.of.kind, ends - starts + 1L)
+    ans
 })
 
 ### 'selfmatch_mapping' must be an integer vector like one returned by
@@ -394,17 +394,14 @@ setMethod("rank", "Vector",
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### xtfrm()
 ###
-### The method below is implemented on top of order(), extractROWS and 
-### sameAsLastROW().
+### The method below is implemented on top of order().
 ###
 
 setMethod("xtfrm", "Vector", function(x) {
     o <- order(x)
-    y <- extractROWS(x, o)
-    is.unique <- !sameAsLastROW(y)
-    out.rank <- cumsum(is.unique)
-    out.rank[o] <- out.rank
-    out.rank
+    ans <- integer(NROW(x))
+    ans[o] <- seq_along(ans)
+    ans
 })
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/R/Vector-comparison.R
+++ b/R/Vector-comparison.R
@@ -83,7 +83,7 @@ setMethod("sameAsLastROW", "ANY", function(x) {
 ### sameAsLastROWS() and order().
 ###
 
-setMethod("match", c("DataFrame", "DataFrame"), 
+setMethod("match", c("Vector", "Vector"), 
     function(x, table, nomatch = NA_integer_, incomparables = NULL, ...) 
 {
     # table first, so stable ordering means that, of matched entries,
@@ -398,7 +398,7 @@ setMethod("rank", "Vector",
 ### sameAsLastROW().
 ###
 
-setMethod("xtfrm", "DataFrame", function(x) {
+setMethod("xtfrm", "Vector", function(x) {
     o <- order(x)
     y <- extractROWS(x, o)
     is.unique <- !sameAsLastROW(y)

--- a/R/Vector-comparison.R
+++ b/R/Vector-comparison.R
@@ -60,6 +60,30 @@ setMethods("<", .OP2_SIGNATURES, function(e1, e2) { !(e2 <= e1) })
 
 setMethods(">", .OP2_SIGNATURES, function(e1, e2) { !(e1 <= e2) })
 
+### Methods for common base types.
+
+setMethod("pcompare", c("numeric", "numeric"), function(x, y) {
+    as.integer(sign(x - y))
+})
+
+setMethod("pcompare", c("ANY", "ANY"), function(x, y) {
+    combined <- bindROWS(x, list(y))
+    original <- c(seq_len(NROW(x)), seq_len(NROW(y)))
+    is.x <- rep(c(TRUE, FALSE), c(NROW(x), NROW(y)))
+
+    o <- order(combined)
+    original <- original[o]
+    is.x <- is.x[o]
+
+    grouping <- cumsum(!sameAsLastROW(extractROWS(combined, o)))
+    x.groups <- integer(NROW(x))
+    x.groups[original[is.x]] <- grouping[is.x]
+    y.groups <- integer(NROW(y))
+    y.groups[original[!is.x]] <- grouping[!is.x]
+
+    pcompare(x.groups, y.groups)
+})
+
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Comparisons along the ROWS
 ###

--- a/man/DataFrame-comparison.Rd
+++ b/man/DataFrame-comparison.Rd
@@ -5,6 +5,9 @@
 \alias{match,DataFrame,DataFrame-method}
 \alias{order,DataFrame-method}
 
+\alias{pcompare,DataFrame,DataFrame-method}
+\alias{==,DataFrame,DataFrame-method}
+\alias{<=,DataFrame,DataFrame-method}
 
 \title{DataFrame comparison methods}
 
@@ -30,7 +33,8 @@
   Note that a \code{match} method for \code{DataFrame} objects is 
   explicitly defined to avoid calling the corresponding method for 
   \code{\link{List}} objects, which would yield the (undesired) list-like
-  semantics.
+  semantics. The same rationale is behind the explicit definition of
+  \code{<=} and \code{==} despite the availability of \code{pcompare}.
 }
 
 \usage{
@@ -40,10 +44,16 @@
 
 \S4method{order}{DataFrame}(..., na.last = TRUE, decreasing = FALSE, method = c("auto", 
     "shell", "radix"))
+
+\S4method{pcompare}{DataFrame,DataFrame}(x, y)
+
+\S4method{==}{DataFrame,DataFrame}(e1, e2)
+
+\S4method{<=}{DataFrame,DataFrame}(e1, e2)
 }
 
 \arguments{
-  \item{x, table}{
+  \item{x, table, y, e1, e2}{
     A \code{\linkS4class{DataFrame}} object.
   }
   \item{nomatch, incomparables}{
@@ -65,6 +75,8 @@
   For \code{match}: see \code{\link[base]{match}}.
 
   For \code{order}: see \code{\link[base]{order}}.
+
+  For \code{pcompare}, \code{==} and \code{<=}: see \code{\link{pcompare}}.
 }
 
 \author{
@@ -86,6 +98,10 @@ unique(DF)
 # Ordering, alone and with other vectors:
 sort(DF)
 order(DF, runif(nrow(DF)))
+
+# Parallel comparison:
+DF==DF
+DF==DF[1,]
 }
 
 \keyword{methods}

--- a/man/DataFrame-comparison.Rd
+++ b/man/DataFrame-comparison.Rd
@@ -1,0 +1,91 @@
+\name{DataFrame-comparison}
+\docType{methods}
+
+\alias{sameAsLastROW,DataFrame-method}
+\alias{match,DataFrame,DataFrame-method}
+\alias{order,DataFrame-method}
+
+
+\title{DataFrame comparison methods}
+
+\description{
+  The \code{DataFrame} class provides methods to compare across
+  rows of the \code{DataFrame}, including ordering and matching. Each
+  \code{DataFrame} is effectively treated as a vector of rows.
+}
+
+\details{
+  The treatment of a \code{DataFrame} as a \dQuote{vector of rows}
+  is useful in many cases, e.g., when each row is a record that needs
+  to be ordered or matched. The methods provided here allow the use of
+  all methods described in \code{?\link{Vector-comparison}}, including
+  sorting, matching, de-duplication, and so on.
+  
+  Careful readers will notice this behaviour differs from the usual 
+  semantics of a \code{data.frame}, which acts as a list-like vector 
+  of columns. This discrepancy rarely causes problems, as it is not
+  particularly common to compare columns of a \code{data.frame} in 
+  the first place.
+
+  Note that a \code{match} method for \code{DataFrame} objects is 
+  explicitly defined to avoid calling the corresponding method for 
+  \code{\link{List}} objects, which would yield the (undesired) list-like
+  semantics.
+}
+
+\usage{
+\S4method{sameAsLastROW}{DataFrame}(x)
+
+\S4method{match}{DataFrame,DataFrame}(x, table, nomatch = NA_integer_, incomparables = NULL, ...)
+
+\S4method{order}{DataFrame}(..., na.last = TRUE, decreasing = FALSE, method = c("auto", 
+    "shell", "radix"))
+}
+
+\arguments{
+  \item{x, table}{
+    A \code{\linkS4class{DataFrame}} object.
+  }
+  \item{nomatch, incomparables}{
+    See \code{?base::\link[base]{match}}.
+  }
+  \item{...}{
+    For \code{match}, further arguments to pass to \code{\link[base]{match}}.
+
+    For \code{order}, one or more \code{\linkS4class{DataFrame}} objects.
+  }
+  \item{decreasing, na.last, method}{
+    See \code{?base::\link[base]{order}}.
+  }
+}
+
+\value{
+  For \code{sameAsLastROW}: see \code{\link{sameAsLastROW}}.
+
+  For \code{match}: see \code{\link[base]{match}}.
+
+  For \code{order}: see \code{\link[base]{order}}.
+}
+
+\author{
+  Aaron Lun
+}
+
+\examples{
+# Mocking up a DataFrame.
+DF <- DataFrame(
+    A=sample(LETTERS, 100, replace=TRUE),
+    B=sample(5, 100, replace=TRUE)
+)
+
+# Matching:
+match(DF, DF[1:10,])
+selfmatch(DF)
+unique(DF)
+
+# Ordering, alone and with other vectors:
+sort(DF)
+order(DF, runif(nrow(DF)))
+}
+
+\keyword{methods}

--- a/man/Vector-comparison.Rd
+++ b/man/Vector-comparison.Rd
@@ -366,10 +366,21 @@ setMethod(">", c("Vector", "Vector"),
           it works out-of-the-box on a \link{Vector} object for which those
           things work the expected way.
 
-    \item The \pkg{S4Vectors} package provides no \code{order}
-          methods for \link{Vector} objects. Specific methods need to be
+    \item The \pkg{S4Vectors} package provides no \code{order} 
+          methods for \link{Vector} objects. Calling \code{order} on a 
+          \link{Vector} object will use \code{base::order}, which calls
+          \code{xtfrm}, with in turn calls \code{order}, which calls 
+          \code{xtfrm}, and so on. This infinite recursion of S4 dispatch
+          eventually results in an error about reaching the stack limit.
+
+          To avoid this behavior, a specialized \code{order} method needs to be
           implemented for specific \link{Vector} subclasses (e.g. for
           \link{Hits} and \link[IRanges]{IntegerRanges} objects).
+          Alternatively, a specialized \code{xtfrm} can be implemented.
+
+          Only one of \code{order} or \code{xtfrm} needs to be supplied
+          to avoid the infinite loop. Of course, there are no problems
+          with implementing both if some efficiency gain is anticipated.
   }
 }
 

--- a/man/Vector-comparison.Rd
+++ b/man/Vector-comparison.Rd
@@ -28,9 +28,13 @@
 \alias{>,Vector,ANY-method}
 \alias{>,ANY,Vector-method}
 
+\alias{match}
+\alias{match,Vector,Vector-method}
+
 \alias{selfmatch}
 \alias{selfmatch,ANY-method}
 \alias{selfmatch,factor-method}
+\alias{selfmatch,Vector-method}
 
 \alias{duplicated,Vector-method}
 \alias{duplicated.Vector}
@@ -50,8 +54,12 @@
 \alias{sort,Vector-method}
 \alias{sort.Vector}
 \alias{rank,Vector-method}
+\alias{xtfrm,Vector-method}
 
 \alias{table,Vector-method}
+
+\alias{sameAsLastROW}
+\alias{sameAsLastROW,ANY-method}
 
 \title{Compare, order, tabulate vector-like objects}
 
@@ -90,10 +98,21 @@ pcompare(x, y)
 \S4method{>}{Vector,ANY}(e1, e2)
 \S4method{>}{ANY,Vector}(e1, e2)
 
+## match()
+## -----------
+
+\S4method{match}{Vector,Vector}(x, table, nomatch = NA_integer_, 
+    incomparables = NULL, ...) 
+
 ## selfmatch()
 ## -----------
 
 selfmatch(x, ...)
+
+## sameAsLastROW()
+## -----------
+
+sameAsLastROW(x)
 
 ## duplicated() & unique()
 ## -----------------------
@@ -126,6 +145,11 @@ countMatches(x, table, ...)
 
 \S4method{sort}{Vector}(x, decreasing=FALSE, na.last=NA, by)
 
+## xtfrm()
+## ------
+
+\S4method{xtfrm}{Vector}(x)
+
 ## table()
 ## -------
 
@@ -135,6 +159,9 @@ countMatches(x, table, ...)
 \arguments{
   \item{x, y, e1, e2, table}{
     Vector-like objects.
+  }
+  \item{nomatch}{
+    See \code{?base::\link[base]{match}}.
   }
   \item{incomparables}{
     The \code{duplicated} method for \link{Vector} objects does NOT
@@ -146,7 +173,10 @@ countMatches(x, table, ...)
 
     See \code{?base::\link[base]{duplicated}} and
     \code{?base::\link[base]{unique}} for more information about this
-    argument.
+    argument for these generics.
+
+    The \code{match} method for \link{Vector} objects does support
+    this argument, see \code{?base::\link[base]{match}} for details.
   }
   \item{select}{
     Only \code{select="all"} is supported at the moment.
@@ -212,10 +242,10 @@ countMatches(x, table, ...)
   vector then \code{pcompare(x, y)} returns a zero-length integer vector.
 
   \code{selfmatch(x, ...)} is equivalent to \code{match(x, x, ...)}. This
-  is actually how the default method is implemented. However note that
-  \code{selfmatch(x, ...)} will typically be more efficient than
-  \code{match(x, x, ...)} on vector-like objects for which a specific
-  \code{selfmatch} method is implemented.
+  is actually how the default \code{ANY} method is implemented. However note that
+  the default \code{selfmatch(x, ...)} for \link{Vector} \code{x} will typically 
+  be more efficient than \code{match(x, x, ...)}, and can be made even more so
+  if a specific \code{selfmatch} method is implemented for a given subclass.
 
   \code{findMatches} is an enhanced version of \code{match} which, by default
   (i.e. if \code{select="all"}), returns all the matches in a \link{Hits}
@@ -229,7 +259,8 @@ countMatches(x, table, ...)
 \value{
   For \code{pcompare}: see Details section above.
 
-  For \code{selfmatch}: an integer vector of the same length as \code{x}.
+  For \code{match} and \code{selfmatch}: an integer vector of the 
+  same length as \code{x}.
 
   For \code{duplicated}, \code{unique}, and \code{\%in\%}: see
   \code{?BiocGenerics::\link[BiocGenerics]{duplicated}},
@@ -244,6 +275,12 @@ countMatches(x, table, ...)
   in \code{x}.
 
   For \code{sort}: see \code{?BiocGenerics::\link[BiocGenerics]{sort}}.
+
+  For \code{xtfrm}: see \code{?base::\link[base]{xtfrm}}.
+
+  For \code{sameAsLastROW}: a logical vector of length equal to \code{x},
+  indicating whether each entry of \code{x} is equal to the previous entry. 
+  The first entry is always \code{FALSE} for a non-zero-length \code{x}.
 
   For \code{table}: a 1D array of integer values promoted to the
   \code{"table"} class. See \code{?BiocGeneric::\link[BiocGenerics]{table}}
@@ -293,6 +330,22 @@ setMethod(">", c("Vector", "Vector"),
           specific methods must obey the rules described in the Details
           section above.
 
+    \item The \code{match} methods for \linkS4class{Vector} objects are 
+          implemented on top of \code{selfmatch}, so they work out-of-the-box 
+          on \link{Vector} objects for which \code{selfmatch} works as expected.
+
+    \item \code{selfmatch} is itself implemented on top of \code{xtfrm},
+          (indirectly, via \code{\link{grouping}}) so it will work out-of-the-box 
+          on \link{Vector} objects for which \code{xtfrm} works as expected.
+
+    \item \code{xtfrm} is, in turn, implemented on top of \code{order} and
+          \code{sameAsLastROW}, so it will work out-of-the-box on \link{Vector} 
+          objects for which \code{order} and \code{sameAsLastROW} work as expected.
+
+    \item \code{sameAsLastROW} is implemented on top of the \code{==} method,
+          so will work out-of-the-box on \link{Vector} objects for which 
+          \code{==} works as expected.
+
     \item The \code{duplicated}, \code{unique}, and \code{\%in\%} methods for
           \link{Vector} objects are implemented on top of \code{selfmatch},
           \code{duplicated}, and \code{match}, respectively, so they work
@@ -304,12 +357,6 @@ setMethod(">", c("Vector", "Vector"),
           work out-of-the-box on \link{Vector} objects for which those things
           work the expected way.
 
-    \item However, since \code{selfmatch} itself is also implemented on top of
-          \code{match}, then having \code{match} work the expected way is
-          actually enough to get \code{selfmatch}, \code{duplicated},
-          \code{unique}, \code{\%in\%}, \code{findMatches}, and
-          \code{countMatches} work out-of-the-box on \link{Vector} objects.
-
     \item The \code{sort} method for \link{Vector} objects is implemented on
           top of \code{order}, so it works out-of-the-box on \link{Vector}
           objects for which \code{order} works the expected way.
@@ -319,7 +366,7 @@ setMethod(">", c("Vector", "Vector"),
           it works out-of-the-box on a \link{Vector} object for which those
           things work the expected way.
 
-    \item The \pkg{S4Vectors} package provides no \code{match} or \code{order}
+    \item The \pkg{S4Vectors} package provides no \code{order}
           methods for \link{Vector} objects. Specific methods need to be
           implemented for specific \link{Vector} subclasses (e.g. for
           \link{Hits} and \link[IRanges]{IntegerRanges} objects).


### PR DESCRIPTION
As suggested in #32. Use like so:

```r
DF <- DataFrame(
    A=sample(LETTERS, 100, replace=TRUE),
    B=sample(5, 100, replace=TRUE)
)
match(DF, DF[1:10,])
selfmatch(DF)
sort(DF)
order(DF, runif(nrow(DF)))
```

The underlying principle is to treat the `DataFrame` as a vector along its rows. This does deviate from the implementation specifics, where it is a list of the columns. Perhaps some more formal decisions need to be made about which dimension is the primary one. I daresay that most people would consider the rows to be the "elements" of a data frame-like object (in the sense that each row is a separate data point). Only people like us would think of a data frame as a list along the columns.

In any case, `data.frame` itself is rather schizophrenic about this entire business. `duplicated.data.frame` behaves as if the rows were elements, `order` on a `data.frame` seems to concatenate all columns together to make a long vector, and `match` treats it like a list of columns.

