### PR TITLE
More informative errors from rbinding DataFrames

### DIFF
--- a/R/DataFrame-class.R
+++ b/R/DataFrame-class.R
@@ -932,7 +932,13 @@ setMethod("show", "DataFrame",
                  x_col <- x[[i]]
                  other_cols <- lapply(seq_along(objects),
                                       function(j) objects[[j]][[colmaps[i, j]]])
-                 .bind_cols_along_their_ROWS(c(list(x_col), other_cols))
+                 tryCatch( 
+                     .bind_cols_along_their_ROWS(c(list(x_col), other_cols)),
+                     error=function(err) {
+                        stop("failed to rbind '", colnames(x)[i], 
+                            "' across DataFrames\n", conditionMessage(err))
+                     }
+                 )
             }
         )
         ans_nrow <- NROW(ans_listData[[1L]])

--- a/R/DataFrame-class.R
+++ b/R/DataFrame-class.R
@@ -837,9 +837,16 @@ setMethod("show", "DataFrame",
                       "must have the same number of columns"))
         colmap <- selectHits(findMatches(x_colnames, object_colnames),
                              select="first", nodup=TRUE)
-        if (anyNA(colmap))
+        if (anyNA(colmap)) {
+            delta <- c(setdiff(x_colnames, object_colnames),
+                setdiff(object_colnames, x_colnames))
+            delta <- sprintf("'%s'", delta)
+            if (length(delta)>3) delta <- c(head(delta, 3), "...")
+            delta <- paste(delta, collapse=", ")
             stop(wmsg("the DataFrame objects to rbind ",
-                      "must have the same colnames"))
+                      "have mismatching colnames ", 
+                      paste0("(", delta, ")")))
+        }
         colmap
     }
     if (length(objects) == 0L) {

--- a/R/DataFrame-class.R
+++ b/R/DataFrame-class.R
@@ -936,7 +936,7 @@ setMethod("show", "DataFrame",
                      .bind_cols_along_their_ROWS(c(list(x_col), other_cols)),
                      error=function(err) {
                         stop("failed to rbind '", colnames(x)[i], 
-                            "' across DataFrames\n", conditionMessage(err))
+                            "' across DataFrames\n  ", conditionMessage(err))
                      }
                  )
             }

--- a/R/DataFrame-class.R
+++ b/R/DataFrame-class.R
@@ -843,17 +843,20 @@ setMethod("show", "DataFrame",
     }
 
     if (length(misleft) && length(misright)) {
-        paste0("(", .format_failed_colnames(misleft), 
+        msg <- paste0("(", .format_failed_colnames(misleft), 
             " vs ", .format_failed_colnames(misright), ")")
     } else if (length(misleft)) {
-        paste0("(", .format_failed_colnames(misleft), " ",
+        msg <- paste0("(", .format_failed_colnames(misleft), " ",
             if (length(misleft) > 1) "are" else "is",
             " unique)")
     } else {
-        paste0("(", .format_failed_colnames(misright), " ",
+        msg <- paste0("(", .format_failed_colnames(misright), " ",
             if (length(misright) > 1) "are" else "is",
             " unique)")
     }
+
+    stop(wmsg("the DataFrame objects to rbind do not have ",
+              "identical column names ", msg))
 }
 
 ### Return an integer matrix with 1 column per object in 'objects' and 1 row
@@ -864,17 +867,12 @@ setMethod("show", "DataFrame",
     x_ncol <- length(x_colnames)
     map_x_colnames_to_object_colnames <- function(object_colnames) {
         if (length(object_colnames) != x_ncol) {
-            stop(wmsg("the DataFrame objects to rbind ",
-                      "have different numbers of columns ",
-                      .format_mismatch_message(x_colnames, object_colnames)))
+            .format_mismatch_message(x_colnames, object_colnames)
         }
-
         colmap <- selectHits(findMatches(x_colnames, object_colnames),
                              select="first", nodup=TRUE)
         if (anyNA(colmap)) {
-            stop(wmsg("the DataFrame objects to rbind ",
-                      "have mismatching colnames ", 
-                      .format_mismatch_message(x_colnames, object_colnames)))
+            .format_mismatch_message(x_colnames, object_colnames)
         }
         colmap
     }
@@ -964,8 +962,8 @@ setMethod("show", "DataFrame",
                  tryCatch( 
                      .bind_cols_along_their_ROWS(c(list(x_col), other_cols)),
                      error=function(err) {
-                        stop("failed to rbind '", colnames(x)[i], 
-                            "' across DataFrames\n  ", conditionMessage(err))
+                        stop("failed to rbind column '", colnames(x)[i], 
+                            "' across DataFrames:\n  ", conditionMessage(err))
                      }
                  )
             }


### PR DESCRIPTION
```r
library(S4Vectors)
A <- DataFrame(A=10)
B <- DataFrame(B=10)
rbind(A, B)
## Error in map_x_colnames_to_object_colnames(colnames(object)) : 
##   the DataFrame objects to rbind have mismatching colnames ('A', 'B')
```

```r
library(S4Vectors)
A <- DataFrame(A=I(matrix(10)))
B <- DataFrame(A=I(cbind(1,2)))
rbind(A, B)
## Error in value[[3L]](cond) : failed to rbind 'A' across DataFrames
##   number of columns of matrices must match (see arg 2)
```

... which at least gives the user some indication of what went wrong.