### PR TITLE
Native support for groupInfo slot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,13 +8,13 @@ Description: The S4Vectors package defines the Vector and List virtual classes
 	interest (e.g. DataFrame, Rle, and Hits) are implemented in the
 	S4Vectors package itself (many more are implemented in the IRanges
 	package and in other Bioconductor infrastructure packages).
-Version: 0.25.12
+Version: 0.25.13
 Encoding: UTF-8
 Author: H. Pagès, M. Lawrence and P. Aboyoun
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
 biocViews: Infrastructure, DataRepresentation
 Depends: R (>= 3.3.0), methods, utils, stats, stats4, BiocGenerics (>= 0.31.1)
-Suggests: IRanges, GenomicRanges, SummarizedExperiment, Matrix, DelayedArray, ShortRead, graph, data.table, RUnit, BiocStyle
+Suggests: IRanges, GenomicRanges, SummarizedExperiment, Matrix, DelayedArray, ShortRead, graph, data.table, dplyr, RUnit, BiocStyle
 License: Artistic-2.0
 Collate: S4-utils.R
 	show-utils.R

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,7 +1,7 @@
 useDynLib(S4Vectors)
 
 import(methods)
-importFrom(utils, head, tail, head.matrix, tail.matrix, getS3method)
+importFrom(utils, head, tail, head.matrix, tail.matrix, getS3method, hasName)
 importFrom(stats, cov, cor, median, quantile,
            smoothEnds, runmed, window, "window<-", aggregate,
            na.omit, na.exclude, complete.cases, setNames, terms)
@@ -220,7 +220,7 @@ exportMethods(
     length, names, "names<-",
     dim, nrow, ncol,
     NROW, NCOL,
-    groupInfo, "groupInfo<-",
+    groupCols, "groupCols<-",
     dimnames, "dimnames<-",
     rownames, "rownames<-",
     colnames, "colnames<-",

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -220,6 +220,7 @@ exportMethods(
     length, names, "names<-",
     dim, nrow, ncol,
     NROW, NCOL,
+    groupInfo, "groupInfo<-",
     dimnames, "dimnames<-",
     rownames, "rownames<-",
     colnames, "colnames<-",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+CHANGES IN VERSION 0.25.0
+-------------------------
+
+NEW FEATURES
+
+    o Add native support for groupwise operations via groupInfo, with getter, setter,
+      and constructor support (by Jonathan Carroll).
+
+
 CHANGES IN VERSION 0.24.0
 -------------------------
 

--- a/R/DataFrame-class.R
+++ b/R/DataFrame-class.R
@@ -174,7 +174,7 @@ setGeneric("groupInfo<-", function(x, value) standardGeneric("groupInfo<-"))
 setReplaceMethod("groupInfo", "DataFrame", 
                  function(x, value) { 
                    if (!is.null(value) && !is.character(value))
-                     stop("replacement 'groupInfo' value must be NULL or a list")
+                     stop("replacement 'groupInfo' value must be NULL or character vector")
                    x@groupInfo <- value
                    x
                  })
@@ -254,6 +254,18 @@ new_DataFrame <- function(listData=list(), nrows=NA, groupInfo = NULL, what="arg
     if (!is.integer(nrows))
         nrows <- as.integer(nrows)
     listData_nrow <- nrow(listData)
+    if (!is.null(groupInfo(listData))) {
+      if (!is.null(groupInfo)) {
+        stop("groupInfo provided explicitly when data already has groups.")
+      } else {
+        groups <- groupInfo(listData)
+      }
+    }
+    if (!is.null(groupInfo)) {
+      groups <- groupInfo
+    } else {
+      groups <- NULL
+    }
     if (is.null(listData_nrow)) {
         ## 'listData' is NOT a data.frame or data-frame-like object.
         if (length(listData) == 0L) {
@@ -280,7 +292,7 @@ new_DataFrame <- function(listData=list(), nrows=NA, groupInfo = NULL, what="arg
         }
         listData <- as.list(listData)
     }
-    new2("DFrame", nrows=nrows, listData=listData, groupInfo=groupInfo, check=FALSE)
+    new2("DFrame", nrows=nrows, listData=listData, groupInfo=groups, check=FALSE)
 }
 
 DataFrame <- function(..., row.names = NULL, groupInfo = NULL, check.names = TRUE,
@@ -1146,7 +1158,9 @@ cbind.DataFrame <- function(..., deparse.level=1)
     ## because then DataFrame() wouldn't be able to deparse what was in ...
     ## and selectMethod("cbind", "DataFrame")(b) would produce a DataFrame
     ## with a column named "11:13".
-    DataFrame(..., check.names=FALSE)
+    ## Group information is taken from the first argument, so if 
+    ## trying to preserve groups, use the grouped object first.
+    DataFrame(..., groupInfo = groupInfo(..1), check.names=FALSE)
 }
 
 setMethod("cbind", "DataFrame", cbind.DataFrame)

--- a/R/DataTable-class.R
+++ b/R/DataTable-class.R
@@ -324,8 +324,8 @@ make_class_info_for_DataTable_display <- function(x)
         " and ",
         x_ncol, " column", ifelse(x_ncol == 1L, "", "s"),
         "\n", sep="")
-    if (!is.null(groupInfo(x))) {
-      cat("Groups: ", toString(groupInfo(x)), "\n")
+    if (!is.null(groupCols(x))) {
+      cat("Groups: ", toString(groupCols(x)), "\n")
     }
     if (x_nrow != 0L && x_ncol != 0L) {
         x_rownames <- rownames(x)

--- a/R/DataTable-class.R
+++ b/R/DataTable-class.R
@@ -324,6 +324,9 @@ make_class_info_for_DataTable_display <- function(x)
         " and ",
         x_ncol, " column", ifelse(x_ncol == 1L, "", "s"),
         "\n", sep="")
+    if (!is.null(groupInfo(x))) {
+      cat("Groups: ", toString(groupInfo(x)), "\n")
+    }
     if (x_nrow != 0L && x_ncol != 0L) {
         x_rownames <- rownames(x)
         if (x_nrow <= nhead + ntail + 1L) {

--- a/man/DataFrame-class.Rd
+++ b/man/DataFrame-class.Rd
@@ -13,6 +13,8 @@
 % accessor
 \alias{nrow,DataFrame-method}
 \alias{ncol,DataFrame-method}
+\alias{groupInfo,DataFrame-method}
+\alias{groupInfo<-,DataFrame-method}
 \alias{rownames,DataFrame-method}
 \alias{colnames,DataFrame-method}
 \alias{rownames<-,DataFrame-method}
@@ -37,6 +39,9 @@
 \alias{coerce,Vector,DFrame-method}
 \alias{coerce,data.frame,DFrame-method}
 \alias{coerce,data.table,DFrame-method}
+\alias{coerce,tbl_df,DFrame-method}
+\alias{coerce,grouped_df,DFrame-method}
+\alias{coerce,DFrame-method,tbl_df}
 \alias{coerce,NULL,DFrame-method}
 \alias{coerce,table,DFrame-method}
 \alias{coerce,AsIs,DFrame-method}
@@ -96,7 +101,7 @@
 \section{Constructor}{
   \describe{
     \item{}{
-      \code{DataFrame(..., row.names = NULL, check.names = TRUE,
+      \code{DataFrame(..., row.names = NULL, groupInfo = NULL, check.names = TRUE,
                       stringsAsFactors)}
 
       Constructs a \code{DataFrame} in similar fashion to
@@ -116,6 +121,13 @@
       The \code{stringsAsFactors} argument is ignored. The coercion of
       column arguments to DataFrame determines whether strings
       become factors.
+      
+      \code{groupInfo} can be supplied to label columns which should 
+      participate in group-wise operations (provided by extension packages).
+      Alternatively, if grouping information is already present in the supplied
+      object (e.g. via \code{\link[dplyr]{group_by}}) this will be used to 
+      infer \code{groupInfo}. An additional header line will list the 
+      group columns when the \code{DataFrame} is printed.
     }
     \item{}{
       \code{make_zero_col_DFrame(nrow)}
@@ -138,6 +150,9 @@
       Get and set the two element list containing the row names
       (character vector of length \code{nrow(x)} or \code{NULL})
       and the column names (character vector of length \code{ncol(x)}).
+    }
+    \item{}{\code{groupInfo(x)}, \code{groupInfo(x) <- value}: Get and set the 
+    grouping information (character vector of column names).
     }
   }
 }
@@ -312,6 +327,9 @@ df[["counts"]]
 df[[3]] <- score
 df[["X"]]
 df[[3]] <- NULL # deletion
+
+# group information
+DataFrame(mtcars, groupInfo = c("am", "gear"))
 }
 \keyword{classes}
 \keyword{methods}

--- a/man/DataFrame-class.Rd
+++ b/man/DataFrame-class.Rd
@@ -13,8 +13,8 @@
 % accessor
 \alias{nrow,DataFrame-method}
 \alias{ncol,DataFrame-method}
-\alias{groupInfo,DataFrame-method}
-\alias{groupInfo<-,DataFrame-method}
+\alias{groupCols,DataFrame-method}
+\alias{groupCols<-,DataFrame-method}
 \alias{rownames,DataFrame-method}
 \alias{colnames,DataFrame-method}
 \alias{rownames<-,DataFrame-method}
@@ -101,7 +101,7 @@
 \section{Constructor}{
   \describe{
     \item{}{
-      \code{DataFrame(..., row.names = NULL, groupInfo = NULL, check.names = TRUE,
+      \code{DataFrame(..., row.names = NULL, check.names = TRUE,
                       stringsAsFactors)}
 
       Constructs a \code{DataFrame} in similar fashion to
@@ -121,13 +121,6 @@
       The \code{stringsAsFactors} argument is ignored. The coercion of
       column arguments to DataFrame determines whether strings
       become factors.
-      
-      \code{groupInfo} can be supplied to label columns which should 
-      participate in group-wise operations (provided by extension packages).
-      Alternatively, if grouping information is already present in the supplied
-      object (e.g. via \code{\link[dplyr]{group_by}}) this will be used to 
-      infer \code{groupInfo}. An additional header line will list the 
-      group columns when the \code{DataFrame} is printed.
     }
     \item{}{
       \code{make_zero_col_DFrame(nrow)}
@@ -151,7 +144,7 @@
       (character vector of length \code{nrow(x)} or \code{NULL})
       and the column names (character vector of length \code{ncol(x)}).
     }
-    \item{}{\code{groupInfo(x)}, \code{groupInfo(x) <- value}: Get and set the 
+    \item{}{\code{groupCols(x)}, \code{groupCols(x) <- value}: Get and set the 
     grouping information (character vector of column names).
     }
   }
@@ -329,7 +322,8 @@ df[["X"]]
 df[[3]] <- NULL # deletion
 
 # group information
-DataFrame(mtcars, groupInfo = c("am", "gear"))
+d <- DataFrame(mtcars)
+groupCols(d) <- c("am", "gear")
 }
 \keyword{classes}
 \keyword{methods}


### PR DESCRIPTION
I propose enabling native support for group information and submit a draft implementation.

One of the advantages of `dplyr` and `tibble` is support for groupwise operations. `dplyr` stores a `tbl_df` of group information; grouping columns with the non-empty combinations of levels (named by their respective column name in the data) and .rows which is a list of rownames to which the grouping results. e.g. in `dplyr`:
```r
group_data(group_by(mtcars, am, gear))
# A tibble: 4 x 3
     am  gear .rows     
  <dbl> <dbl> <list>    
1     0     3 <int [15]>
2     0     4 <int [4]> 
3     1     4 <int [8]> 
4     1     5 <int [5]> 
```
This approach has the drawback (in my opinion) that this listing of .rows must be updated with every operation which alters the number of rows (including `[`, `filter`, `slice`, `rbind`, etc... ). An alternative (and the approach used here) is to store only the names of the columns which should be involved in further groupwise operations. 
```r
str(DataFrame(mtcars[1:4,1:4], groupInfo = c("am", "gear")))
Formal class 'DFrame' [package "S4Vectors"] with 7 slots
  ..@ rownames       : chr [1:4] "Mazda RX4" "Mazda RX4 Wag" "Datsun 710" "Hornet 4 Drive"
  ..@ nrows          : int 4
  ..@ groupInfo      : chr [1:2] "am" "gear"
  ..@ listData       :List of 4
  .. ..$ mpg : num [1:4] 21 21 22.8 21.4
  .. ..$ cyl : num [1:4] 6 6 4 6
  .. ..$ disp: num [1:4] 160 160 108 258
  .. ..$ hp  : num [1:4] 110 110 93 110
  ..@ elementType    : chr "ANY"
  ..@ elementMetadata: NULL
  ..@ metadata       : list()
```
I provide accessors and replacement functions for this slot, but leave any processing of the data to whichever code can make use of the information. I have added `dplyr` consistency only in the creation of a `DataFrame` from an already grouped `tbl_df` or conversion back to one
```r
groupInfo(as(group_by(mtcars, am, gear), "DataFrame"))
[1] "am"   "gear"
```
This way, methods which act on individual columns of a `DataFrame` can delegate how to perform the groupwise action. Where this may be of significant benefit is e.g. `plyranges` (ping: @sa-lee) for which a `GRanges` column may be better suited to perform the groupwise operation internally rather than sliced into rows.

I have tested the implementation in this PR with a branch of `DFplyr` which aims to extend `dplyr` support to `DataFrame`: https://github.com/jonocarroll/DFplyr/tree/native_groupInfo and as far as I can tell this is successful.

This PR is intended as a draft and I welcome feedback. My implementation may not be ideal but hopefully serves as a starting point.