### PR TITLE
Expanded available methods for DataFrameFactors.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Collate: S4-utils.R
 	DataFrame-combine.R
 	DataFrame-comparison.R
 	DataFrame-utils.R
+    DataFrameFactor-class.R
 	TransposedDataFrame-class.R
 	Pairs-class.R
 	FilterRules-class.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Collate: S4-utils.R
 	DataFrame-combine.R
 	DataFrame-comparison.R
 	DataFrame-utils.R
-    DataFrameFactor-class.R
+	DataFrameFactor-class.R
 	TransposedDataFrame-class.R
 	Pairs-class.R
 	FilterRules-class.R

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -28,10 +28,9 @@ exportClasses(
     List, list_OR_List,
     SimpleList,
     HitsList, SortedByQueryHitsList,
-    DataFrame, DFrame, TransposedDataFrame,
+    DataFrame, DFrame, DataFrameFactor, TransposedDataFrame,
     Pairs,
-    expression_OR_function, FilterRules, FilterMatrix,
-    DataFrameFactor
+    expression_OR_function, FilterRules, FilterMatrix
 )
 
 
@@ -364,14 +363,14 @@ export(
     ## DataFrame-class.R:
     DataFrame, make_zero_col_DFrame,
 
+    ## DataFrameFactor-class:
+    DataFrameFactor,
+
     ## Pairs-class.R:
     Pairs,
 
     ## FilterRules-class.R:
-    FilterRules, FilterMatrix,
-
-    ## DataFrameFactor-class:
-    DataFrameFactor
+    FilterRules, FilterMatrix
 )
 
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -30,7 +30,8 @@ exportClasses(
     HitsList, SortedByQueryHitsList,
     DataFrame, DFrame, TransposedDataFrame,
     Pairs,
-    expression_OR_function, FilterRules, FilterMatrix
+    expression_OR_function, FilterRules, FilterMatrix,
+    DataFrameFactor
 )
 
 
@@ -365,7 +366,10 @@ export(
     Pairs,
 
     ## FilterRules-class.R:
-    FilterRules, FilterMatrix
+    FilterRules, FilterMatrix,
+
+    ## DataFrameFactor-class:
+    DataFrameFactor
 )
 
 

--- a/R/DataFrameFactor-class.R
+++ b/R/DataFrameFactor-class.R
@@ -15,9 +15,7 @@ setMethod("dim", "DataFrameFactor", function(x) c(length(x), ncol(levels(x))))
 
 setMethod("dimnames", "DataFrameFactor", function(x) list(names(x), colnames(levels(x))))
 
-setMethod("[[", "DataFrameFactor", function(x, i, j, ...) levels(x)[as.integer(x),i])
-
-setMethod("$", "DataFrameFactor", function(x, name) x[[name]])
+setMethod("$", "DataFrameFactor", function(x, name) levels(x)[as.integer(x),name])
 
 setMethod("[", "DataFrameFactor", function(x, i, j, ..., drop=TRUE) {
     if (!missing(i)) {

--- a/R/DataFrameFactor-class.R
+++ b/R/DataFrameFactor-class.R
@@ -1,6 +1,6 @@
 setClass("DataFrameFactor", contains="Factor", slots=c(levels="DataFrame"))
 
-DataFrameFactor <- function (x, levels, index = NULL, ...) {
+DataFrameFactor <- function(x, levels, index = NULL, ...) {
     if (is.null(index)) {
         levels <- sort(unique(x))
         index <- match(x, levels) 
@@ -23,7 +23,7 @@ setMethod("[", "DataFrameFactor", function(x, i, j, ..., drop=TRUE) {
     if (!missing(i)) {
         x <- callNextMethod()
     } 
-    
+
     if (!missing(j)) {
         x@levels <- levels(x)[,j,drop=FALSE]
     }

--- a/R/DataFrameFactor-class.R
+++ b/R/DataFrameFactor-class.R
@@ -1,9 +1,14 @@
 setClass("DataFrameFactor", contains="Factor", slots=c(levels="DataFrame"))
 
 DataFrameFactor <- function (x, levels, index = NULL, ...) {
-    f <- Factor(x, levels, index=index, ...)
-    f@levels <- DataFrame(as.list(f@levels)) # hack
-    as(f, "DataFrameFactor")
+    if (is.null(index)) {
+        levels <- sort(unique(x))
+        index <- match(x, levels) 
+        names(index) <- rownames(x)
+    }
+    out <- Factor(levels=seq_len(nrow(levels)), index=index, ...)
+    out@levels <- levels
+    as(out, "DataFrameFactor")
 }
 
 setMethod("dim", "DataFrameFactor", function(x) c(length(x), ncol(levels(x))))
@@ -15,19 +20,16 @@ setMethod("[[", "DataFrameFactor", function(x, i, j, ...) levels(x)[as.integer(x
 setMethod("$", "DataFrameFactor", function(x, name) x[[name]])
 
 setMethod("[", "DataFrameFactor", function(x, i, j, ..., drop=TRUE) {
-    if (!missing(j)) {
-        sub.levels <- levels(x)[,j,drop=FALSE]
-        new.levels <- unique(sub.levels)
-        x@index <- match(sub.levels, new.levels)[x@index]
-        x@levels <- new.levels
-    }
-
     if (!missing(i)) {
-        x <- extractROWS(x, i)
+        x <- callNextMethod()
+    } 
+    
+    if (!missing(j)) {
+        x@levels <- levels(x)[,j,drop=FALSE]
     }
 
-    if (drop && ncol(x)==1L) {
-        x <- x[[1]]
+    if (drop && ncol(levels(x))==1L) {
+        x <- levels(x)[as.integer(x),1]
     }
 
     x

--- a/R/DataFrameFactor-class.R
+++ b/R/DataFrameFactor-class.R
@@ -1,0 +1,39 @@
+setClass("DataFrameFactor", contains="Factor", slots=c(levels="DataFrame"))
+
+DataFrameFactor <- function (x, levels, index = NULL, ...) {
+    f <- Factor(x, levels, index=index, ...)
+    f@levels <- DataFrame(as.list(f@levels)) # hack
+    as(f, "DataFrameFactor")
+}
+
+setMethod("dim", "DataFrameFactor", function(x) c(length(x), ncol(levels(x))))
+
+setMethod("dimnames", "DataFrameFactor", function(x) list(names(x), colnames(levels(x))))
+
+setMethod("[[", "DataFrameFactor", function(x, i, j, ...) levels(x)[as.integer(x),i])
+
+setMethod("$", "DataFrameFactor", function(x, name) x[[name]])
+
+setMethod("[", "DataFrameFactor", function(x, i, j, ..., drop=TRUE) {
+    if (!missing(j)) {
+        sub.levels <- levels(x)[,j,drop=FALSE]
+        new.levels <- unique(sub.levels)
+        x@index <- match(sub.levels, new.levels)[x@index]
+        x@levels <- new.levels
+    }
+
+    if (!missing(i)) {
+        x <- extractROWS(x, i)
+    }
+
+    if (drop && ncol(x)==1L) {
+        x <- x[[1]]
+    }
+
+    x
+})
+
+setMethod("show", "DataFrameFactor", function(object) {
+    callNextMethod()
+    coolcat("colnames(%i): %s\n", colnames(object))
+})

--- a/inst/unitTests/test_DataFrameFactor-class.R
+++ b/inst/unitTests/test_DataFrameFactor-class.R
@@ -1,0 +1,21 @@
+test_DataFrameFactor <- function() {
+     df <- DataFrame(X=sample(5, 100, replace=TRUE), Y=sample(c("A", "B"), 100, replace=TRUE))
+
+     dffac <- DataFrameFactor(df)
+     checkIdentical(dim(dffac), dim(df))
+     checkIdentical(dimnames(dffac), dimnames(df))
+
+     checkIdentical(dffac$X, df$X)
+     checkIdentical(dffac[["X"]], df$X)
+
+     checkIdentical(unfactor(dffac[,c("Y", "X")]), df[,c("Y", "X")])
+     checkIdentical(dffac[1:10,"X"], df$X[1:10])
+
+     # The usual Factor methods may also be used:
+     checkIdentical(unfactor(dffac), df)
+     checkTrue(!anyDuplicated(levels(dffac)))
+
+     # Check that the row names are registered correctly.
+     names(dffac) <- 1:100
+     checkIdentical(names(dffac), as.character(1:100))
+}

--- a/inst/unitTests/test_DataFrameFactor-class.R
+++ b/inst/unitTests/test_DataFrameFactor-class.R
@@ -6,7 +6,7 @@ test_DataFrameFactor <- function() {
      checkIdentical(dimnames(dffac), dimnames(df))
 
      checkIdentical(dffac$X, df$X)
-     checkIdentical(dffac[["X"]], df$X)
+     checkIdentical(dffac[,"X"], df$X)
 
      checkIdentical(unfactor(dffac[,c("Y", "X")]), df[,c("Y", "X")])
      checkIdentical(dffac[1:10,"X"], df$X[1:10])

--- a/man/DataFrameFactor-class.Rd
+++ b/man/DataFrameFactor-class.Rd
@@ -18,10 +18,10 @@
 \title{DataFrameFactor objects}
 
 \description{
-  The DataFrameFactor class is a subclass of the \link{Factor} class
-  where the levels are the rows of a \link{DataFrame}. It provides
-  a few methods to mimic the behavior of an actual \link{DataFrame}
-  while retaining the memory efficiency of the \link{Factor} structure.
+  The DataFrameFactor class is a subclass of the \link{Factor} class where the
+  levels are the rows of a \link{DataFrame}. It provides a few methods to mimic
+  the behavior of an actual \link{DataFrame} while retaining the memory
+  efficiency of the \link{Factor} structure.
 }
 
 \usage{
@@ -33,7 +33,7 @@ DataFrameFactor(x, levels, index=NULL, ...)  # constructor function
     \link{DataFrame} objects. At least one of \code{x} and \code{levels} must
     be specified. If \code{index} is \code{NULL}, both can be specified.
 
-    When \code{levels} is specified, it must be a \link{DataFrame} with no 
+    When \code{levels} is specified, it must be a \link{DataFrame} with no
     duplicate rows (i.e. \code{anyDuplicated(levels)} must return 0).
 
     See \code{?\link{Factor}} for more details.
@@ -52,29 +52,41 @@ DataFrameFactor(x, levels, index=NULL, ...)  # constructor function
 }
 
 \section{Accessors}{
-  DataFrameFactor objects support the same set of accessors as \link{Factor} objects.
-  In addition, it mimics some aspects of the \link{DataFrame} interface. The general
-  principle is that, for these methods, a DataFrameFactor \code{x} behaves the same
-  as the expanded DataFrame \code{\link{unfactor}(x)}.
+  DataFrameFactor objects support the same set of accessors as \link{Factor}
+  objects.  In addition, it mimics some aspects of the \link{DataFrame}
+  interface. The general principle is that, for these methods, a
+  DataFrameFactor \code{x} behaves like the expanded DataFrame
+  \code{\link{unfactor}(x)}.
 
   \itemize{
-    \item \code{x[[i]]} will return column \code{i} from \code{\link{levels}(x)}
-    and expand it according to the indices in \code{x}.
+    \item \code{x[[i]]} will return column \code{i} from
+    \code{\link{levels}(x)} and expand it according to the indices in \code{x}.
 
-    \item \code{x$name} will return column \code{name} from \code{\link{levels}(x)}
-    and expand it according to the indices in \code{x}.
-    
+    \item \code{x$name} will return column \code{name} from
+    \code{\link{levels}(x)} and expand it according to the indices in \code{x}.
+
     \item \code{x[i, j, ..., drop=TRUE]} will return a new DataFrameFactor
     subsetted to entries \code{i}, where the levels are subsetted by column to
     contain only columns \code{j}. If the resulting levels only have one column
-    and \code{drop=TRUE}, the expanded values of the column is returned directly.
+    and \code{drop=TRUE}, the expanded values of the column are returned
+    directly.
 
     \item \code{dim(x)} will return the length of the DataFrameFactor and the
     number of columns in its levels.
 
-    \item \code{dimnames(x)} will return the names of the DataFrameFactor and the
-    column names in its levels.
+    \item \code{dimnames(x)} will return the names of the DataFrameFactor and
+    the column names in its levels.
   }
+}
+
+\section{Caution}{
+The \link{DataFrame}-like methods implemented here are for convenience only.
+Users should not assume that the DataFrameFactor complies with other aspects of
+the DataFrame interface, due to fundamental differences between a DataFrame and
+the \link{Factor} parent class, e.g., in the interpretation of their
+\dQuote{length}. Outside of the methods listed above, the DataFrameFactor is
+not guaranteed to work as a drop-in replacement for a DataFrame - use
+\code{unfactor(x)} instead.
 }
 
 \author{Aaron Lun}

--- a/man/DataFrameFactor-class.Rd
+++ b/man/DataFrameFactor-class.Rd
@@ -1,0 +1,104 @@
+\name{DataFrameFactor-class}
+\docType{class}
+
+\alias{class:DataFrameFactor}
+\alias{DataFrameFactor-class}
+\alias{DataFrameFactor}
+
+\alias{dim,DataFrameFactor-method}
+\alias{dimnames,DataFrameFactor-method}
+
+\alias{[,DataFrameFactor-method}
+\alias{[,DataFrameFactor,ANY,ANY,ANY-method}
+\alias{[[,DataFrameFactor-method}
+\alias{[[,DataFrameFactor,ANY,ANY-method}
+\alias{$,DataFrameFactor-method}
+\alias{show,DataFrameFactor-method}
+
+\title{DataFrameFactor objects}
+
+\description{
+  The DataFrameFactor class is a subclass of the \link{Factor} class
+  where the levels are the rows of a \link{DataFrame}. It provides
+  a few methods to mimic the behavior of an actual \link{DataFrame}
+  while retaining the memory efficiency of the \link{Factor} structure.
+}
+
+\usage{
+DataFrameFactor(x, levels, index=NULL, ...)  # constructor function
+}
+
+\arguments{
+  \item{x, levels}{
+    \link{DataFrame} objects. At least one of \code{x} and \code{levels} must
+    be specified. If \code{index} is \code{NULL}, both can be specified.
+
+    When \code{levels} is specified, it must be a \link{DataFrame} with no 
+    duplicate rows (i.e. \code{anyDuplicated(levels)} must return 0).
+
+    See \code{?\link{Factor}} for more details.
+  }
+  \item{index}{
+    \code{NULL} or an integer (or numeric) vector of valid positive indices
+    (no \code{NA}s) into \code{levels}. See \code{?\link{Factor}} for details.
+  }
+  \item{...}{
+    Optional metadata columns.
+  }
+}
+
+\value{
+  A DataFrameFactor object.
+}
+
+\section{Accessors}{
+  DataFrameFactor objects support the same set of accessors as \link{Factor} objects.
+  In addition, it mimics some aspects of the \link{DataFrame} interface. The general
+  principle is that, for these methods, a DataFrameFactor \code{x} behaves the same
+  as the expanded DataFrame \code{\link{unfactor}(x)}.
+
+  \itemize{
+    \item \code{x[[i]]} will return column \code{i} from \code{\link{levels}(x)}
+    and expand it according to the indices in \code{x}.
+
+    \item \code{x$name} will return column \code{name} from \code{\link{levels}(x)}
+    and expand it according to the indices in \code{x}.
+    
+    \item \code{x[i, j, ..., drop=TRUE]} will return a new DataFrameFactor
+    subsetted to entries \code{i}, where the levels are subsetted by column to
+    contain only columns \code{j}. If the resulting levels only have one column
+    and \code{drop=TRUE}, the expanded values of the column is returned directly.
+
+    \item \code{dim(x)} will return the length of the DataFrameFactor and the
+    number of columns in its levels.
+
+    \item \code{dimnames(x)} will return the names of the DataFrameFactor and the
+    column names in its levels.
+  }
+}
+
+\author{Aaron Lun}
+
+\seealso{
+\link{Factor} objects for the parent class.
+}
+
+\examples{
+df <- DataFrame(X=sample(5, 100, replace=TRUE), Y=sample(c("A", "B"), 100, replace=TRUE))
+dffac <- DataFrameFactor(df)
+dffac
+
+dffac$X
+dffac[["X"]]
+dffac[,c("Y", "X")]
+dffac[1:10,"X"]
+colnames(dffac)
+
+# The usual Factor methods may also be used:
+unfactor(dffac)
+levels(dffac)
+as.integer(dffac)
+}
+
+\keyword{methods}
+\keyword{classes}

--- a/man/DataFrameFactor-class.Rd
+++ b/man/DataFrameFactor-class.Rd
@@ -59,9 +59,6 @@ DataFrameFactor(x, levels, index=NULL, ...)  # constructor function
   \code{\link{unfactor}(x)}.
 
   \itemize{
-    \item \code{x[[i]]} will return column \code{i} from
-    \code{\link{levels}(x)} and expand it according to the indices in \code{x}.
-
     \item \code{x$name} will return column \code{name} from
     \code{\link{levels}(x)} and expand it according to the indices in \code{x}.
 
@@ -101,7 +98,6 @@ dffac <- DataFrameFactor(df)
 dffac
 
 dffac$X
-dffac[["X"]]
 dffac[,c("Y", "X")]
 dffac[1:10,"X"]
 colnames(dffac)


### PR DESCRIPTION
This allows us to treat `DataFrameFactor`s as `DataFrame`s. For example, doing something like `x$name` will return the same value as `unfactor(x)$name`, allowing us to use DFFs as memory-efficient drop-in replacements for DFs in many cases.

Ideally the `Factor()` constructor would handle proper construction, but I just couldn't figure out how to get:

```r
df <- DataFrame(X=sample(5, 100, replace=TRUE), Y=sample(c("A", "B"), 100, replace=TRUE))
dffac <- Factor(df)
dffac
## Factor object of length 100 with 0 metadata columns
## Levels: SimpleList object of length 2
```

to work - you can see how it just converts the `DFrame` to a `SimpleList`. It's still the former inside `.encode_as_Factor`, but once it enters `new()` it magically collapses to the latter. Not sure how this is happening.

Also ideally the `show` method would be more informative, maybe even giving the same kind of preview that `DataFrame` does.
