### PR TITLE
Fixed handling of nested DFs in combineUniqueCols.

### DIFF
--- a/R/RectangularData-class.R
+++ b/R/RectangularData-class.R
@@ -228,22 +228,22 @@ combineUniqueCols <- function(x, ..., use.names=TRUE)
 
                 candidates <- match(rownames(cur_object), rownames(combined))
                 overlapped <- filled[candidates]
-                previous <- reference[candidates]
+                previous <- extractROWS(reference, candidates)
 
                 # Only doing the replacement if the overlaps are identical.
                 # Incidentally, this also checks for the right type. We could
                 # be more aggressive and do a partial replacement, but
                 # something is probably already wrong if this warning fires.
-                if (!identical(previous[overlapped], replacements[overlapped])) {
+                if (!identical(extractROWS(previous, overlapped), extractROWS(replacements, overlapped))) {
                     warning(wmsg("different values for shared rows in multiple instances of column '",
                         d, "', ignoring this column in ", class(all_objects[[i_object]]), " ", i_object))
                 } else {
-                    reference[candidates] <- replacements
+                    reference <- replaceROWS(reference, candidates, replacements)
                     filled[candidates] <- TRUE
                 }
             }
 
-            combined[,d] <- reference
+            combined[[d]] <- reference
 
         } else {
             for (i in seq_along(object_affected)[-1]) {

--- a/inst/unitTests/test_RectangularData-class.R
+++ b/inst/unitTests/test_RectangularData-class.R
@@ -65,6 +65,18 @@ test_combineUniqueCols <- function() {
 
     # Unary case works correctly.
     checkIdentical(combineUniqueCols(X), X)
+
+    # Handles nested DFs properly.
+    x <- DataFrame(X=I(DataFrame(A=1:5)), row.names=1:5)
+    y <- DataFrame(X=I(DataFrame(A=1:5)), row.names=1:5)
+    out <- combineUniqueCols(x, y)
+    checkIdentical(out$X$A, 1:5)
+
+    y2 <- DataFrame(X=I(DataFrame(A=2:6, B=letters[1:5])), row.names=2:6)
+    out <- combineUniqueCols(x, y2) # should trigger a warning where X$B is effectively dropped.
+    checkIdentical(colnames(out), "X")
+    checkIdentical(colnames(out$X), "A")
+    checkIdentical(out$X$A, c(1:5, NA))
 }
 
 test_combineUniqueCols_unnamed <- function() {


### PR DESCRIPTION
Currently:

```r
library(S4Vectors)
x <- DataFrame(X=I(DataFrame(A=1:5)), row.names=1:5)
y <- DataFrame(X=I(DataFrame(A=1:5)), row.names=1:5)
combineUniqueCols(x, y)
## Error: subscript contains out-of-bounds indices
```

With the fix:

```r
combineUniqueCols(x, y)
## DataFrame with 5 rows and 1 column
##             X
##   <DataFrame>
## 1           1
## 2           2
## 3           3
## 4           4
## 5           5
```

This is running on 0.32.3, etc.