### PR TITLE
add fortify.DataFrame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Authors@R: c(
 	person("Beryl", "Kanali", role="ctb",
 		comment="Converted 'RleTricks' vignette from Sweave to RMarkdown."))
 Depends: R (>= 4.0.0), methods, utils, stats, stats4, BiocGenerics (>= 0.37.0)
-Suggests: IRanges, GenomicRanges, SummarizedExperiment, Matrix, DelayedArray, ShortRead, graph, data.table, RUnit, BiocStyle, knitr
+Suggests: IRanges, GenomicRanges, SummarizedExperiment, Matrix, DelayedArray, ShortRead, graph, data.table, RUnit, BiocStyle, knitr, ggplot2
 VignetteBuilder: knitr
 Collate: S4-utils.R
 	show-utils.R
@@ -63,6 +63,7 @@ Collate: S4-utils.R
 	DataFrame-comparison.R
 	DataFrame-utils.R
 	DataFrameFactor-class.R
+	fortify.R
 	TransposedDataFrame-class.R
 	Pairs-class.R
 	FilterRules-class.R
@@ -71,3 +72,4 @@ Collate: S4-utils.R
 	aggregate-methods.R
 	shiftApply-methods.R
 	zzz.R
+RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,4 +72,3 @@ Collate: S4-utils.R
 	aggregate-methods.R
 	shiftApply-methods.R
 	zzz.R
-RoxygenNote: 7.2.3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,6 +6,7 @@ importFrom(stats, cov, cor, median, quantile,
            smoothEnds, runmed, window, "window<-", aggregate,
            na.omit, na.exclude, complete.cases, setNames, terms)
 importFrom(stats4, summary, update)
+importFrom(ggplot2, fortify)
 
 import(BiocGenerics)
 
@@ -78,6 +79,8 @@ S3method(droplevels, List)
 
 S3method(duplicated, Vector)
 S3method(duplicated, DataFrame)
+
+S3method(fortify, DataFrame)
 
 S3method(head, LLint)
 S3method(head, RectangularData)

--- a/R/fortify.R
+++ b/R/fortify.R
@@ -1,0 +1,5 @@
+#' @export
+#' @importFrom ggplot2 fortify
+fortify.DataFrame <- function(model, data, ...) {
+  as.data.frame(model)
+}


### PR DESCRIPTION
Hi there

TL;DR: This PR makes the following code possible:

```
library(S4Vectors)

df <- DataFrame(
  x = 1:10,
  y = rnorm(10)
)

library(ggplot2)

ggplot(df, aes(x, y)) +
  geom_point()

# see also:
fortify(df)
```

Without the need for `as.data.frame(df)` in the `ggplot()` call.

----

Context:

As per https://community-bioc.slack.com/archives/C6KJHH0M9/p1690235172607369

I've messed around `S4vectors` a bit to test feasibility, and somehow landed on my feet with something that seems to work.

I'll be honest, I'm not even sure why R allows me to do it, but it seems that I can `importFrom` a package that is listed in `Suggests` (i.e., not in `Depends`).

I added `ggplot2` to `Suggests` because I don't like the idea of having it under `Imports`. It just feels wrong to automatically install `ggplot2` and its own dependencies as a dependency of `S4Vectors`. `S4Vectors` should remain a lightweight package.

I suppose that if users have `ggplot2` installed, the import statement "just works", and if they don't have `ggplot2` installed.. well... they don't have any reason to call `ggplot()` on a `DataFrame` object :D

I'm aware that this PR is unlikely to be the final fix (if any is possible at all). I just aim to give a starting point to the discussion.

Also, I've considered other approaches, but run into chicken-and-egg issues:

- I suspect `ggplot2` will not accept to `Suggests: S4Vectors`, as I don't see any Bioconductor package in its existing Imports/Suggests (https://cran.r-project.org/web/packages/ggplot2/index.html) and `install.packages()` cannot see Bioconductor packages without messing with `options(repos)`.
- I suspect `S4Vectors` will not accept to `Imports: ggplot2`, to justify more cleanly `importFrom(ggplot2, fortify)`. Same reason as above: keep S4Vectors dependencies to a minimum
- I noted that `?ggplot2::fortify` states "Rather than using this function, I now recommend using the broom package, which implements a much wider range of methods. fortify() may be deprecated in the future." However, it is not clear to me what needs to be done in [broom](https://cran.r-project.org/web/packages/broom/index.html) (or [biobroom](https://bioconductor.org/packages/release/bioc/html/biobroom.html)) 