### PR TITLE
add format string to fix Wformat-security warnings

### DIFF
--- a/src/Rle_class.c
+++ b/src/Rle_class.c
@@ -1133,7 +1133,7 @@ SEXP _subset_Rle_by_ranges(SEXP x,
 			mapped_range_Rtrim,
 			method);
 	if (errmsg != NULL)
-		error(errmsg);
+		error("%s", errmsg);
 	for (i = 0; i < nranges; i++)
 		mapped_range_start[i]++;  /* add 1 to get the starts */
 	return subset_Rle_by_mapped_ranges(x,
@@ -1158,7 +1158,7 @@ SEXP _subset_Rle_by_positions(SEXP x, const int *pos, int npos, int method)
 			mapped_pos,
 			method);
 	if (errmsg != NULL)
-		error(errmsg);
+		error("%s", errmsg);
 	return subset_Rle_by_mapped_pos(x, mapped_pos, npos);
 }
 
@@ -1187,7 +1187,7 @@ SEXP Rle_extract_range(SEXP x, SEXP start, SEXP end)
 				&mapped_range_Ltrim,
 				&mapped_range_Rtrim);
 	if (errmsg != NULL)
-		error(errmsg);
+		error("%s", errmsg);
 	mapped_range_offset++;  /* add 1 to get the start */
 	return extract_Rle_mapped_range(x_values, INTEGER(x_lengths),
 				mapped_range_offset,

--- a/src/map_ranges_to_runs.c
+++ b/src/map_ranges_to_runs.c
@@ -679,7 +679,7 @@ SEXP map_ranges(SEXP run_lengths, SEXP start, SEXP width, SEXP method)
 			INTEGER(method)[0]);
 	if (errmsg != NULL) {
 		UNPROTECT(4);
-		error(errmsg);
+		error("%s", errmsg);
 	}
 	PROTECT(ans = NEW_LIST(4));
 	SET_VECTOR_ELT(ans, 0, mapped_range_offset);
@@ -706,7 +706,7 @@ SEXP map_positions(SEXP run_lengths, SEXP pos, SEXP method)
 			INTEGER(method)[0]);
 	if (errmsg != NULL) {
 		UNPROTECT(1);
-		error(errmsg);
+		error("%s", errmsg);
 	}
 	UNPROTECT(1);
 	return mapped_pos;


### PR DESCRIPTION
Compiling S4Vectors on R-devel (`2023-12-14 r85685`) produces `Wformat-security` compiler warnings. When using the bioconductor devel docker container, these warnings are prompted to errors, due to the `-Werror=format-security` CFLAG being set. These warnings aren't seen in the Bioconductor build system because the R devel version is older (`2023-11-11 r85510`) than the version in devel docker container.

It's unclear to me what changes occurred in R-devel to cause these warnings. However adding a format string `"%s"` to code using the  R API `error()` calls without a formatting string argument removes the warnings.

Here are the compiler errors seen when using the devel docker container:
```
docker run --rm -it bioconductor/bioconductor_docker:devel R -e 'BiocManager::install("S4Vectors")'
* installing *source* package ‘S4Vectors’ ...
** using staged installation
** libs
using C compiler: ‘gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0’
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c AEbufs.c -o AEbufs.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c DataFrame_class.c -o DataFrame_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c Hits_class.c -o Hits_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c LLint_class.c -o LLint_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c List_class.c -o List_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c R_init_S4Vectors.c -o R_init_S4Vectors.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c Rle_class.c -o Rle_class.o
Rle_class.c: In function ‘_subset_Rle_by_ranges’:
Rle_class.c:1136:17: error: format not a string literal and no format arguments [-Werror=format-security]
 1136 |                 error(errmsg);
      |                 ^~~~~
Rle_class.c: In function ‘_subset_Rle_by_positions’:
Rle_class.c:1161:17: error: format not a string literal and no format arguments [-Werror=format-security]
 1161 |                 error(errmsg);
      |                 ^~~~~
Rle_class.c: In function ‘Rle_extract_range’:
Rle_class.c:1190:17: error: format not a string literal and no format arguments [-Werror=format-security]
 1190 |                 error(errmsg);
      |                 ^~~~~
cc1: some warnings being treated as errors
make: *** [/usr/local/lib/R/etc/Makeconf:191: Rle_class.o] Error 1
ERROR: compilation failed for package ‘S4Vectors’
* removing ‘/usr/local/lib/R/site-library/S4Vectors’

The downloaded source packages are in
	‘/tmp/RtmpFqMjYJ/downloaded_packages’
Warning message:
In install.packages(...) :
  installation of package ‘S4Vectors’ had non-zero exit status
```

Here are the warnings seen when instead compiling with the same CFLAGS as the bioc build system `-O2 -Wall -g`:

```
> BiocManager::install("S4Vectors")
'getOption("repos")' replaces Bioconductor standard repositories, see
'help("repositories", package = "BiocManager")' for details.
Replacement repositories:
    CRAN: https://cloud.r-project.org
Bioconductor version 3.19 (BiocManager 1.30.22), R Under development (unstable)
  (2023-12-14 r85685)
Installing package(s) 'S4Vectors'
trying URL 'https://bioconductor.org/packages/3.19/bioc/src/contrib/S4Vectors_0.41.2.tar.gz'
Content type 'application/x-gzip' length 838154 bytes (818 KB)
==================================================
downloaded 818 KB

* installing *source* package ‘S4Vectors’ ...
** using staged installation
** libs
using C compiler: ‘gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0’
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c AEbufs.c -o AEbufs.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c DataFrame_class.c -o DataFrame_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c Hits_class.c -o Hits_class.o
In file included from /usr/local/lib/R/include/Rdefines.h:41,
                 from ../inst/include/S4Vectors_defines.h:18,
                 from S4Vectors.h:1,
                 from Hits_class.c:4:
Hits_class.c: In function ‘Hits_new’:
/usr/local/lib/R/include/Rinternals.h:893:33: warning: ‘revmap’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  893 | #define defineVar               Rf_defineVar
      |                                 ^~~~~~~~~~~~
Hits_class.c:216:19: note: ‘revmap’ was declared here
  216 |         SEXP ans, revmap, symbol;
      |                   ^~~~~~
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c LLint_class.c -o LLint_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c List_class.c -o List_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c R_init_S4Vectors.c -o R_init_S4Vectors.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c Rle_class.c -o Rle_class.o
Rle_class.c: In function ‘_subset_Rle_by_ranges’:
Rle_class.c:1136:17: warning: format not a string literal and no format arguments [-Wformat-security]
 1136 |                 error(errmsg);
      |                 ^~~~~
Rle_class.c: In function ‘_subset_Rle_by_positions’:
Rle_class.c:1161:17: warning: format not a string literal and no format arguments [-Wformat-security]
 1161 |                 error(errmsg);
      |                 ^~~~~
Rle_class.c: In function ‘Rle_extract_range’:
Rle_class.c:1190:17: warning: format not a string literal and no format arguments [-Wformat-security]
 1190 |                 error(errmsg);
      |                 ^~~~~
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c Rle_utils.c -o Rle_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c SEXP_utils.c -o SEXP_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c SimpleList_class.c -o SimpleList_class.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c anyMissing.c -o anyMissing.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c character_utils.c -o character_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c eval_utils.c -o eval_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c hash_utils.c -o hash_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c integer_utils.c -o integer_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c logical_utils.c -o logical_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c map_ranges_to_runs.c -o map_ranges_to_runs.o
map_ranges_to_runs.c: In function ‘map_ranges’:
map_ranges_to_runs.c:682:17: warning: format not a string literal and no format arguments [-Wformat-security]
  682 |                 error(errmsg);
      |                 ^~~~~
map_ranges_to_runs.c: In function ‘map_positions’:
map_ranges_to_runs.c:709:17: warning: format not a string literal and no format arguments [-Wformat-security]
  709 |                 error(errmsg);
      |                 ^~~~~
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c raw_utils.c -o raw_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c safe_arithm.c -o safe_arithm.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c sort_utils.c -o sort_utils.o
sort_utils.c:263:13: warning: ‘sort_uchar_array’ defined but not used [-Wunused-function]
  263 | static void sort_uchar_array(unsigned char *x, int nelt, int desc)
      |             ^~~~~~~~~~~~~~~~
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c subsetting_utils.c -o subsetting_utils.o
gcc -I"/usr/local/lib/R/include" -DNDEBUG   -I/usr/local/include    -fPIC  -O2 -Wall -g -c vector_utils.c -o vector_utils.o
gcc -shared -L/usr/local/lib/R/lib -L/usr/local/lib -o S4Vectors.so AEbufs.o DataFrame_class.o Hits_class.o LLint_class.o List_class.o R_init_S4Vectors.o Rle_class.o Rle_utils.o SEXP_utils.o SimpleList_class.o anyMissing.o character_utils.o eval_utils.o hash_utils.o integer_utils.o logical_utils.o map_ranges_to_runs.o raw_utils.o safe_arithm.o sort_utils.o subsetting_utils.o vector_utils.o -L/usr/local/lib/R/lib -lR
installing to /usr/local/lib/R/site-library/00LOCK-S4Vectors/00new/S4Vectors/libs
** R
** inst
** byte-compile and prepare package for lazy loading
in method for ‘normalizeSingleBracketReplacementValue’ with signature ‘"List"’: no definition for class “List”
Creating a new generic function for ‘unname’ in package ‘S4Vectors’
Creating a new generic function for ‘expand.grid’ in package ‘S4Vectors’
Creating a new generic function for ‘findMatches’ in package ‘S4Vectors’
Creating a generic function for ‘setequal’ from package ‘base’ in package ‘S4Vectors’
in method for ‘coerce’ with signature ‘"Hits","DFrame"’: no definition for class “DFrame”
Creating a generic function for ‘as.factor’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘tabulate’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘cov’ from package ‘stats’ in package ‘S4Vectors’
Creating a generic function for ‘cor’ from package ‘stats’ in package ‘S4Vectors’
Creating a generic function for ‘smoothEnds’ from package ‘stats’ in package ‘S4Vectors’
Creating a generic function for ‘runmed’ from package ‘stats’ in package ‘S4Vectors’
Creating a generic function for ‘nchar’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘substr’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘substring’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘chartr’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘tolower’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘toupper’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘sub’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘gsub’ from package ‘base’ in package ‘S4Vectors’
Creating a generic function for ‘nlevels’ from package ‘base’ in package ‘S4Vectors’
in method for ‘coerce’ with signature ‘"data.table","DFrame"’: no definition for class “data.table”
Creating a generic function for ‘complete.cases’ from package ‘stats’ in package ‘S4Vectors’
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (S4Vectors)

The downloaded source packages are in
	‘/tmp/RtmpC1iGhN/downloaded_packages’
```

