### PR TITLE
feat: Allow comparison of XVector objects (part 1 of 2)

### DIFF
--- a/inst/include/S4Vectors_interface.h
+++ b/inst/include/S4Vectors_interface.h
@@ -75,18 +75,6 @@ int sort_ints(
 	int *rxbuf2
 );
 
-int sort_void_array(
-	int *base,
-	int base_len,
-	const void *x,
-	size_t elem_size,
-	int desc,
-	int use_double_compar,
-	int use_radix,
-	unsigned short int *rxbuf1,
-	int *rxbuf2
-);
-
 void get_order_of_int_pairs(
 	const int *a,
 	const int *b,
@@ -169,6 +157,18 @@ void get_matches_of_ordered_int_quads(
 	int nomatch,
 	int *out,
 	int out_shift
+);
+
+int sort_void_array(
+	int *base,
+	int base_len,
+	const void *x,
+	size_t elem_size,
+	int desc,
+	int use_double_compar,
+	int use_radix,
+	unsigned short int *rxbuf1,
+	int *rxbuf2
 );
 
 /*

--- a/inst/include/S4Vectors_interface.h
+++ b/inst/include/S4Vectors_interface.h
@@ -75,6 +75,18 @@ int sort_ints(
 	int *rxbuf2
 );
 
+int sort_void_array(
+	int *base,
+	int base_len,
+	const void *x,
+	size_t elem_size,
+	int desc,
+	int use_double_compar,
+	int use_radix,
+	unsigned short int *rxbuf1,
+	int *rxbuf2
+);
+
 void get_order_of_int_pairs(
 	const int *a,
 	const int *b,

--- a/inst/include/_S4Vectors_stubs.c
+++ b/inst/include/_S4Vectors_stubs.c
@@ -85,6 +85,11 @@ DEFINE_CCALLABLE_STUB(int, sort_ints,
 	(     base,     base_len,            x,     desc,     use_radix,                     rxbuf1,      rxbuf2)
 )
 
+DEFINE_CCALLABLE_STUB(int, sort_void_array,
+	(int *base, int base_len, const void *x, size_t elem_size, int desc, int use_double_compar, int use_radix, unsigned short int *rxbuf1, int *rxbuf2),
+	(     base,     base_len,             x,        elem_size,     desc,     use_double_compar,     use_radix,                     rxbuf1,      rxbuf2)
+)
+
 DEFINE_NOVALUE_CCALLABLE_STUB(get_order_of_int_pairs,
 	(const int *a, const int *b, int nelt, int a_desc, int b_desc, int *out, int out_shift),
 	(           a,            b,     nelt,     a_desc,     b_desc,      out,     out_shift)

--- a/inst/include/_S4Vectors_stubs.c
+++ b/inst/include/_S4Vectors_stubs.c
@@ -85,11 +85,6 @@ DEFINE_CCALLABLE_STUB(int, sort_ints,
 	(     base,     base_len,            x,     desc,     use_radix,                     rxbuf1,      rxbuf2)
 )
 
-DEFINE_CCALLABLE_STUB(int, sort_void_array,
-	(int *base, int base_len, const void *x, size_t elem_size, int desc, int use_double_compar, int use_radix, unsigned short int *rxbuf1, int *rxbuf2),
-	(     base,     base_len,             x,        elem_size,     desc,     use_double_compar,     use_radix,                     rxbuf1,      rxbuf2)
-)
-
 DEFINE_NOVALUE_CCALLABLE_STUB(get_order_of_int_pairs,
 	(const int *a, const int *b, int nelt, int a_desc, int b_desc, int *out, int out_shift),
 	(           a,            b,     nelt,     a_desc,     b_desc,      out,     out_shift)
@@ -118,6 +113,11 @@ DEFINE_CCALLABLE_STUB(int, sort_int_quads,
 DEFINE_NOVALUE_CCALLABLE_STUB(get_matches_of_ordered_int_quads,
 	(const int *a1, const int *b1, const int *c1, const int *d1, const int *o1, int nelt1, const int *a2, const int *b2, const int *c2, const int *d2, const int *o2, int nelt2, int nomatch, int *out, int out_shift),
 	(           a1,            b1,            c1,            d1,            o1,     nelt1,            a2,            b2,            c2,            d2,            o2,     nelt2,     nomatch,      out,     out_shift)
+)
+
+DEFINE_CCALLABLE_STUB(int, sort_void_array,
+	(int *base, int base_len, const void *x, size_t elem_size, int desc, int use_double_compar, int use_radix, unsigned short int *rxbuf1, int *rxbuf2),
+	(     base,     base_len,             x,        elem_size,     desc,     use_double_compar,     use_radix,                     rxbuf1,      rxbuf2)
 )
 
 /*

--- a/src/R_init_S4Vectors.c
+++ b/src/R_init_S4Vectors.c
@@ -129,6 +129,7 @@ void R_init_S4Vectors(DllInfo *info)
 	REGISTER_CCALLABLE(_get_matches_of_ordered_int_pairs);
 	REGISTER_CCALLABLE(_get_order_of_int_quads);
 	REGISTER_CCALLABLE(_get_matches_of_ordered_int_quads);
+	REGISTER_CCALLABLE(_sort_void_array);
 
 /* hash_utils.c */
 	REGISTER_CCALLABLE(_new_htab);

--- a/src/S4Vectors.h
+++ b/src/S4Vectors.h
@@ -195,6 +195,18 @@ void _get_matches_of_ordered_int_quads(
 	int out_shift
 );
 
+int _sort_void_array(
+	int *base,
+	int base_len,
+	const void *x,
+	size_t elem_size,
+	int desc,
+	int use_double_compar,
+	int use_radix,
+	unsigned short int *rxbuf1,
+	int *rxbuf2
+);
+
 
 /* hash_utils.c */
 

--- a/src/sort_utils.c
+++ b/src/sort_utils.c
@@ -1396,7 +1396,7 @@ void _get_matches_of_ordered_int_quads(
    respect to 'x'. Otherwise returns 1, or a negative value if an error
    occurred. Has a dedicated switch for sorting float/double...it's clunky,
    but I couldn't think of a better way. Primary use-case is XRaw anyway,
-   so it should be a huge deal. */
+   so it shouldn't be a huge deal. */
 int _sort_void_array(int *base, int base_len,
 						       const void *x, size_t elem_size,
 						       int desc, int use_double_compar,

--- a/src/sort_utils.c
+++ b/src/sort_utils.c
@@ -13,6 +13,8 @@
 
 static const int *aa, *bb, *cc, *dd;
 static int aa_desc, bb_desc, cc_desc, dd_desc;
+static size_t byte_elem_size;
+static const unsigned char *global_byte_array;
 
 #define	COMPARE_TARGET_INTS(target, i1, i2, desc) \
 	((desc) ? (target)[(i2)] - (target)[(i1)] \
@@ -86,11 +88,44 @@ static int compar4_stable(const void *p1, const void *p2)
 	return i1 - i2;
 }
 
+static int comparbyte_stable(const void *p1, const void *p2){
+	int i1, i2, ret;
+	i1 = *((const int *) p1);
+	i2 = *((const int *) p2);
+	ret = memcmp(&(global_byte_array[i1*byte_elem_size]), &(global_byte_array[i2*byte_elem_size]), byte_elem_size);
+	if(aa_desc) ret *= -1;
+	return ret == 0 ? i1 - i2 : ret;
+}
+
+static int compardouble_stable(const void *p1, const void *p2){
+	// can't use memcmp for doubles unfortunately
+	int i1, i2, ret;
+	i1 = *((const int *) p1);
+	i2 = *((const int *) p2);
+	double v1 = ((double*)global_byte_array)[i1];
+	double v2 = ((double*)global_byte_array)[i2];
+	ret = (v1 > v2) - (v1 < v2);
+	if(aa_desc) ret *= -1;
+	return ret == 0 ? i1 - i2 : ret;
+}
+
 static void qsort1(int *base, int base_len, const int *a, int a_desc)
 {
 	aa = a;
 	aa_desc = a_desc;
 	qsort(base, base_len, sizeof(int), compar1_stable);
+}
+
+static void qsort_void(int *base, int base_len, const void *a, size_t a_size,
+								int a_desc, int use_double_compar){
+	// have to cast to bytes so we can index
+	global_byte_array = (const unsigned char*)a;
+	aa_desc = a_desc;
+	byte_elem_size = a_size;
+	if(!use_double_compar)
+		qsort(base, base_len, sizeof(int), comparbyte_stable);
+	else
+		qsort(base, base_len, sizeof(int), compardouble_stable);
 }
 
 static void qsort2(int *base, int base_len,
@@ -1350,3 +1385,58 @@ void _get_matches_of_ordered_int_quads(
 	return;
 }
 
+/****************************************************************************
+ * Getting the order of a void* array using memcmp
+ *
+ */
+
+/* base: 0-based indices into 'x'.
+   rxbuf1, rxbuf2: NULL or user-allocated buffers of length 'base_len'.
+   Returns 0 if nothing to sort, that is, if 'base' is already sorted with
+   respect to 'x'. Otherwise returns 1, or a negative value if an error
+   occurred. Has a dedicated switch for sorting float/double...it's clunky,
+   but I couldn't think of a better way. Primary use-case is XRaw anyway,
+   so it should be a huge deal. */
+int _sort_void_array(int *base, int base_len,
+						       const void *x, size_t elem_size,
+						       int desc, int use_double_compar,
+						       int use_radix, unsigned short int *rxbuf1, int *rxbuf2)
+{
+	// will add this in eventually, not critical for functionality
+	/*
+	int qsort_cutoff, ret, auto_rxbuf1, auto_rxbuf2;
+
+	rxtargets[0] = x;
+	rxdescs[0] = desc;
+
+	qsort_cutoff = (use_radix && can_use_rxsort()) ? 1024 : base_len;
+	ret = lucky_sort_targets(base, base_len, rxtargets, rxdescs, 1, qsort_cutoff);
+	if (ret != 0)
+		return ret != 1;
+
+	auto_rxbuf1 = rxbuf1 == NULL;
+	if (auto_rxbuf1) {
+		rxbuf1 = alloc_rxbuf1(base_len);
+		if (rxbuf1 == NULL)
+			return -1;
+	}
+	auto_rxbuf2 = rxbuf2 == NULL;
+	if (auto_rxbuf2) {
+		rxbuf2 = alloc_rxbuf2(base_len, rxbuf1, auto_rxbuf1);
+		if (rxbuf2 == NULL)
+			return -2;
+	}
+
+	last_rxlevel = 1;
+	base_uidx_buf = rxbuf1;
+	rxsort_rec(base, base_len, rxbuf2, 0, 0);
+
+	if (auto_rxbuf2)
+		free(rxbuf2);
+	if (auto_rxbuf1)
+		free(rxbuf1);
+	*/
+
+	qsort_void(base, base_len, x, elem_size, desc, use_double_compar);
+	return 1;
+}

--- a/src/sort_utils.c
+++ b/src/sort_utils.c
@@ -1403,6 +1403,8 @@ int _sort_void_array(int *base, int base_len,
 						       int use_radix, unsigned short int *rxbuf1, int *rxbuf2)
 {
 	// will add this in eventually, not critical for functionality
+	// Below section is copied from _sort_int_array, will need to be adapted
+	// Until this is incorporated, use_radix, rxbuf1, and rxbuf2 are not used
 	/*
 	int qsort_cutoff, ret, auto_rxbuf1, auto_rxbuf2;
 


### PR DESCRIPTION
This is one of two PRs intended to fix a bug identified in Biostrings here: https://github.com/Bioconductor/Biostrings/issues/51. Part 2 of the PR is located here: https://github.com/Bioconductor/XVector/pull/6.

The bug identified was that comparing a `DNAString` with a single character caused a `C stack too close to limit` error. It turns out that the bug ran a lot deeper--comparison between `XVector` objects was completely broken. For example:

```
x <- XVector(10)
y <- sample(10)
x == y
## Error: C stack usage  7953792 is too close to the limit

XInteger(10) == XInteger(10)
## works fine

XInteger(10) < XInteger(10)
## Error: C stack usage  7953792 is too close to the limit
```

The culprit stems originally from the S4Vectors package. `pcompare` is defined for `Vector` objects, which uses `order` and `sameAsPreviousROW` to perform element-wise comparisons. However, neither of these methods are written for `SharedVector` objects, so they default to whatever we get from dispatch. `order` dispatches to the standard `base::order` function, which always causes a stack overflow when called on a `SharedVector` object. `sameAsPreviousROW` calls the default method in `S4Vector`, which calls `.XVector.equals`, which will always return `c(FALSE, FALSE)` or `c(FALSE, TRUE)` regardless of input size.

This PR adds in the functionality required in the S4Vectors package to support comparison between `SharedVector` objects. This is primarily just a C-level method to order an array -- this was previously in the package, but only supported integer vectors. This comparison uses `memcmp` when possible, but a separate method is included for numeric types because `memcmp` has weird behavior on doubles. Eventually will need to update the code to support the smart dispatch between sorting algorithms like in the other sorting functions, but for now this is sufficient.  