### PR TITLE
Don't need ':::' for exported functions

### DIFF
--- a/R/aggregate-methods.R
+++ b/R/aggregate-methods.R
@@ -53,8 +53,8 @@
 
 
 setMethod("aggregate", "matrix", stats:::aggregate.default)
-setMethod("aggregate", "data.frame", stats:::aggregate.data.frame)
-setMethod("aggregate", "ts", stats:::aggregate.ts)
+setMethod("aggregate", "data.frame", stats::aggregate.data.frame)
+setMethod("aggregate", "ts", stats::aggregate.ts)
 
 ### S3/S4 combo for aggregate.Vector
 aggregate.Vector <- function(x, by, FUN, start=NULL, end=NULL, width=NULL,


### PR DESCRIPTION
These are exported:

https://github.com/r-devel/r-svn/blob/53078c4ee1ac4aec8a3620d07d44e27eaf77a3ef/src/library/stats/NAMESPACE#L14
https://github.com/r-devel/r-svn/blob/53078c4ee1ac4aec8a3620d07d44e27eaf77a3ef/src/library/stats/NAMESPACE#L100

As reported by `tools:::.check_packages_used`