### PR TITLE
Fix potential integer overflow bug with comparisons in `sort_utils.c`

### DIFF
--- a/src/sort_utils.c
+++ b/src/sort_utils.c
@@ -14,9 +14,11 @@
 static const int *aa, *bb, *cc, *dd;
 static int aa_desc, bb_desc, cc_desc, dd_desc;
 
+#define CMP_INTS(a, b) (((a) > (b)) - ((a) < (b)))
+
 #define	COMPARE_TARGET_INTS(target, i1, i2, desc) \
-	((desc) ? (target)[(i2)] - (target)[(i1)] \
-		: (target)[(i1)] - (target)[(i2)])
+	((desc) ? CMP_INTS((target)[(i2)], (target)[(i1)]) \
+		: CMP_INTS((target)[(i1)], (target)[(i2)]))
 
 static int compar1_stable(const void *p1, const void *p2)
 {

--- a/src/sort_utils.c
+++ b/src/sort_utils.c
@@ -16,9 +16,9 @@ static int aa_desc, bb_desc, cc_desc, dd_desc;
 
 #define CMP_INTS(a, b) (((a) > (b)) - ((a) < (b)))
 
-#define	COMPARE_TARGET_INTS(target, i1, i2, desc) \
-	((desc) ? CMP_INTS((target)[(i2)], (target)[(i1)]) \
-		: CMP_INTS((target)[(i1)], (target)[(i2)]))
+#define COMPARE_TARGET_INTS(target, i1, i2, desc)    \
+  ((desc) ? CMP_INTS((target)[(i2)], (target)[(i1)]) \
+          : CMP_INTS((target)[(i1)], (target)[(i2)]))
 
 static int compar1_stable(const void *p1, const void *p2)
 {


### PR DESCRIPTION
subtracting large negative numbers from large positive numbers here can cause an integer overflow. It's safer to just use `<` and `>` so avoid these issues.