### PR TITLE
Avoid validRN warning in DataFrame coercion

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,11 @@ SIGNIFICANT USER-VISIBLE CHANGES
 
     o Add missing docs to pass R CMD check without warnings.
 
+BUG FIXES
+
+    o Avoid a warning from as.data.frame() when called with the new 'validRN'
+      argument used by R 4.7.0 during data frame construction (#138).
+
 
 CHANGES IN VERSION 0.48.0
 -------------------------
@@ -814,5 +819,4 @@ BUG FIXES
     o Fix subset() on a zero column DataFrame.
 
     o Fix rendering of Date/time classes as DataFrame columns.
-
 

--- a/R/DataFrame-class.R
+++ b/R/DataFrame-class.R
@@ -775,9 +775,10 @@ setMethod("rep", "DataFrame", function(x, ...) {
 ###
 
 ### S3/S4 combo for as.data.frame.DataFrame
-### Same arguments as as.data.frame.matrix().
+### Same arguments as as.data.frame.matrix(), plus 'validRN' for
+### compatibility with the R 4.7.0 data.frame() implementation.
 as.data.frame.DataFrame <- function(x, row.names=NULL, optional=FALSE,
-                                    make.names=TRUE, ...,
+                                    make.names=TRUE, validRN=TRUE, ...,
                                     stringsAsFactors=FALSE)
 {
     if (!isTRUEorFALSE(make.names))

--- a/inst/unitTests/test_DataFrame-class.R
+++ b/inst/unitTests/test_DataFrame-class.R
@@ -88,6 +88,20 @@ test_DataFrame_construction <- function() {
   checkIdentical(as.data.frame(DF), data.frame(foo=foo, bar=bar))
 }
 
+test_DataFrame_as_data_frame_validRN <- function() {
+  DF <- DataFrame(score = 1:3)
+  warnings <- list()
+  ans <- withCallingHandlers(
+    as.data.frame(DF, optional=TRUE, validRN=FALSE),
+    warning = function(w) {
+      warnings <<- c(warnings, list(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  checkIdentical(warnings, list())
+  checkIdentical(ans, data.frame(score=1:3))
+}
+
 test_DataFrame_aggregate_with_dots <- function() {
   shift <- 100
   df <- DataFrame(g=c("a", "a", "b", "b"), x=1:4, y=11:14)


### PR DESCRIPTION
## Summary
Accept the `validRN` argument introduced by R 4.7.0 in `as.data.frame.DataFrame()`.

## Thanks to maintainers
Thanks to the S4Vectors maintainers for the issue report and for maintaining this Bioconductor infrastructure package.

## Issue or motivation
Fixes #138. R 4.7.0 passes `validRN = FALSE` while constructing a data frame from a `DataFrame`, which currently produces an unnecessary warning.

## Root cause
`as.data.frame.DataFrame()` treated `validRN` as an unsupported argument in `...`, even though base R now supplies it during data-frame construction.

## Change
Add `validRN` to the method signature and add a regression test that verifies the conversion is warning-free when the argument is supplied. Record the fix in `NEWS`.

## Tests
- Focused `validRN` regression test: passed
- `tests/run_unitTests.R`: 85 test functions, 0 errors, 0 failures
- `R CMD build --no-build-vignettes`: passed
- `R CMD check --as-cran --ignore-vignettes --no-manual --no-build-vignettes`: passed with no errors; the existing check reported 1 warning and 6 notes unrelated to this change

## Scope
This does not change row-name validation, data-frame conversion output, or behavior for other unsupported arguments. Vignettes and unrelated check warnings were not changed.
